### PR TITLE
Fix: channel password verification bypass, key never derived or stored

### DIFF
--- a/app/src/main/java/com/roman/zemzeme/ui/ChannelManager.kt
+++ b/app/src/main/java/com/roman/zemzeme/ui/ChannelManager.kt
@@ -129,7 +129,13 @@ class ChannelManager(
     // MARK: - Channel Password and Encryption
     
     private fun verifyChannelPassword(channel: String, password: String): Boolean {
-        // TODO: REMOVE THIS - FOR TESTING ONLY
+        // Derive the AES key from the provided password and store it.
+        // In a P2P mesh there is no central authority to reject a wrong password;
+        // verification is implicit — AES-GCM decryption will fail (auth tag
+        // mismatch) if the key is wrong.
+        val key = deriveChannelKey(password, channel)
+        channelKeys[channel] = key
+        channelPasswords[channel] = password
         return true
     }
     


### PR DESCRIPTION
## Description

`ChannelManager.verifyChannelPassword()` always returns `true` without deriving or storing the AES key. This was left as a testing stub (`// TODO: REMOVE THIS - FOR TESTING ONLY`).

**Impact:**
- Any password is accepted when joining a password-protected channel
- The encryption key is never stored in `channelKeys`, so `decryptChannelMessage()` always returns `null` — encrypted messages can never be read by joiners

### Steps to reproduce

1. User A creates a password-protected channel (via `/password` command)
2. User B joins the channel with **any** password (including a wrong one)
3. User B is accepted regardless of password
4. User B cannot decrypt any messages (key was never stored)

### Fix

`verifyChannelPassword()` now calls `deriveChannelKey()` to derive the AES-256 key via PBKDF2 and stores it in `channelKeys` and `channelPasswords` — matching the behavior of `setChannelPassword()`.

In a P2P mesh with no central authority, verification is implicit: AES-GCM decryption rejects messages if the wrong key was derived (auth tag mismatch).

**Affected version:** 1.0.2

## Checklist

- [x] I have read the contribution guidelines: <https://github.com/permissionlesstech/bitchat-android?tab=readme-ov-file#contributing>
- [x] I have performed a self-review of my code
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>)
- [ ] If it is a core feature, I have added automated tests