### PR TITLE
Fix: Truncate GPS coordinates and remove identifying User-Agent

### DIFF
--- a/app/src/main/java/com/roman/zemzeme/geohash/OpenStreetMapGeocoderProvider.kt
+++ b/app/src/main/java/com/roman/zemzeme/geohash/OpenStreetMapGeocoderProvider.kt
@@ -12,13 +12,17 @@ import kotlinx.coroutines.withContext
 class OpenStreetMapGeocoderProvider : GeocoderProvider {
     private val TAG = "OSMGeocoderProvider"
     private val gson = Gson()
-    private val userAgent = "Zemzeme-Android/1.0"
+    private val userAgent = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.0.0 Mobile Safari/537.36"
+
+    private fun truncateCoord(value: Double): Double =
+        Math.round(value * 100.0) / 100.0
 
     override suspend fun getFromLocation(latitude: Double, longitude: Double, maxResults: Int): List<Address> {
         return withContext(Dispatchers.IO) {
             val lang = Locale.getDefault().toLanguageTag()
-            // Using format=jsonv2 for structured address breakdown
-            val url = "https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=$latitude&lon=$longitude&zoom=18&addressdetails=1&accept-language=$lang"
+            val truncLat = truncateCoord(latitude)
+            val truncLon = truncateCoord(longitude)
+            val url = "https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=$truncLat&lon=$truncLon&zoom=10&addressdetails=1&accept-language=$lang"
 
             try {
                 val request = Request.Builder()

--- a/app/src/main/java/com/roman/zemzeme/update/UpdateManager.kt
+++ b/app/src/main/java/com/roman/zemzeme/update/UpdateManager.kt
@@ -242,7 +242,7 @@ class UpdateManager private constructor(private val context: Context) {
         val request = Request.Builder()
             .url(AppConstants.Update.GITHUB_API_URL)
             .header("Accept", "application/vnd.github.v3+json")
-            .header("User-Agent", "Zemzeme-Android/${getCurrentVersionName()}")
+            .header("User-Agent", "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.0.0 Mobile Safari/537.36")
             .build()
 
         try {
@@ -341,7 +341,7 @@ class UpdateManager private constructor(private val context: Context) {
 
         val requestBuilder = Request.Builder()
             .url(url)
-            .header("User-Agent", "Zemzeme-Android/${getCurrentVersionName()}")
+            .header("User-Agent", "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.0.0 Mobile Safari/537.36")
         if (existingBytes > 0) requestBuilder.header("Range", "bytes=$existingBytes-")
 
         httpClient.newCall(requestBuilder.build()).execute().use { response ->
@@ -377,7 +377,7 @@ class UpdateManager private constructor(private val context: Context) {
     }
 
     private suspend fun downloadApkFresh(url: String, apkFile: File, onProgress: (Float) -> Unit): File = withContext(Dispatchers.IO) {
-        val request = Request.Builder().url(url).header("User-Agent", "Zemzeme-Android/${getCurrentVersionName()}").build()
+        val request = Request.Builder().url(url).header("User-Agent", "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.0.0 Mobile Safari/537.36").build()
         httpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) throw IOException("Download failed: HTTP ${response.code}")
             val body = response.body ?: throw IOException("Empty response body")


### PR DESCRIPTION
**User-Agent string to third-party servers, enabling location tracking and user fingerprinting.**

**Findings**

1. Full-precision GPS coordinates sent to OpenStreetMap (CVSS 7.5)
OpenStreetMapGeocoderProvider.kt sends exact latitude/longitude (full decimal
precision) with zoom=18 (building level) to nominatim.openstreetmap.org. Even through Tor, the OSM server receives the user's precise street-level location. Combined with the identifying User-Agent, this links physical location to app identity.

2. App-identifying User-Agent on all HTTP requests (CVSS 6.5)
The header "Zemzeme-Android/1.0" is sent on every OSM geocoding request and all three GitHub API/download requests in UpdateManager.kt. Any network observer or server
operator can trivially identify the user as a Zemzeme user from this header alone.

**Fix**

- Truncated GPS coordinates to 2 decimal places (~1.1km city-level accuracy) before sending to OSM
- Reduced OSM zoom level from 18 (building) to 10 (city)
- Replaced "Zemzeme-Android/1.0" and "Zemzeme-Android/${version}" with a generic Chrome/Android browser User-Agent across all HTTP requests (OSM + GitHub)

**Impact**
These changes prevent third-party servers and network observers from determining the user's precise location or identifying them as a Zemzeme user via HTTP headers.

**Critical for users in surveillance-heavy environments.**