### PR TITLE
feat: add bilingual mental health assessment bot

### DIFF
--- a/app/src/main/java/com/roman/zemzeme/ui/AssessmentData.kt
+++ b/app/src/main/java/com/roman/zemzeme/ui/AssessmentData.kt
@@ -1,0 +1,73 @@
+package com.roman.zemzeme.ui
+
+import com.roman.zemzeme.R
+
+data class Option(val textEnRes: Int, val textFaRes: Int, val score: Int)
+data class Question(val textEnRes: Int, val textFaRes: Int, val options: List<Option>, val isCritical: Boolean = false)
+data class AssessmentResult(val scoreRange: IntRange, val severityEnRes: Int, val severityFaRes: Int, val nextStepsEnRes: Int, val nextStepsFaRes: Int)
+data class ClinicalAssessment(
+    val id: String,
+    val imageRes: Int? = null,
+    val titleEn: String,
+    val titleFa: String,
+    val descriptionEn: String,
+    val descriptionFa: String,
+    val questions: List<Question>,
+    val results: List<AssessmentResult>
+)
+
+val standardOptions = listOf(
+    Option(R.string.opt_not_at_all_en, R.string.opt_not_at_all_fa, 0),
+    Option(R.string.opt_several_days_en, R.string.opt_several_days_fa, 1),
+    Option(R.string.opt_more_than_half_en, R.string.opt_more_than_half_fa, 2),
+    Option(R.string.opt_nearly_every_en, R.string.opt_nearly_every_fa, 3)
+)
+
+val gad7 = ClinicalAssessment(
+    id = "GAD-7",
+    titleEn = "GAD-7 (General Anxiety Disorder-7)",
+    titleFa = "پرسشنامه اضطراب فراگیر (GAD-7)",
+    descriptionEn = "Over the past 2 weeks, how often have you been bothered by the following?",
+    descriptionFa = "در طی ۲ هفته گذشته، هر چند وقت یک‌بار با مشکلات زیر مواجه بوده‌اید؟",
+    questions = listOf(
+        Question(R.string.gad7_q1_en, R.string.gad7_q1_fa, standardOptions),
+        Question(R.string.gad7_q2_en, R.string.gad7_q2_fa, standardOptions),
+        Question(R.string.gad7_q3_en, R.string.gad7_q3_fa, standardOptions),
+        Question(R.string.gad7_q4_en, R.string.gad7_q4_fa, standardOptions),
+        Question(R.string.gad7_q5_en, R.string.gad7_q5_fa, standardOptions),
+        Question(R.string.gad7_q6_en, R.string.gad7_q6_fa, standardOptions),
+        Question(R.string.gad7_q7_en, R.string.gad7_q7_fa, standardOptions)
+    ),
+    results = listOf(
+        AssessmentResult(0..4, R.string.severity_no_anxiety_en, R.string.severity_no_anxiety_fa, R.string.steps_monitor_en, R.string.steps_monitor_fa),
+        AssessmentResult(5..9, R.string.severity_mild_en, R.string.severity_mild_fa, R.string.steps_monitor_symptom_en, R.string.steps_monitor_symptom_fa),
+        AssessmentResult(10..14, R.string.severity_moderate_en, R.string.severity_moderate_fa, R.string.steps_clinical_en, R.string.steps_clinical_fa),
+        AssessmentResult(15..21, R.string.severity_severe_en, R.string.severity_severe_fa, R.string.steps_referral_en, R.string.steps_referral_fa)
+    )
+)
+
+val phq9 = ClinicalAssessment(
+    id = "PHQ-9",
+    titleEn = "PHQ-9 (Patient Health Questionnaire-9)",
+    titleFa = "پرسشنامه سلامت بیمار (PHQ-9)",
+    descriptionEn = "Over the past 2 weeks, how often have you been bothered by the following?",
+    descriptionFa = "در طی ۲ هفته گذشته، هر چند وقت یک‌بار با مشکلات زیر مواجه بوده‌اید؟",
+    questions = listOf(
+        Question(R.string.phq9_q1_en, R.string.phq9_q1_fa, standardOptions),
+        Question(R.string.phq9_q2_en, R.string.phq9_q2_fa, standardOptions),
+        Question(R.string.phq9_q3_en, R.string.phq9_q3_fa, standardOptions),
+        Question(R.string.phq9_q4_en, R.string.phq9_q4_fa, standardOptions),
+        Question(R.string.phq9_q5_en, R.string.phq9_q5_fa, standardOptions),
+        Question(R.string.phq9_q6_en, R.string.phq9_q6_fa, standardOptions),
+        Question(R.string.phq9_q7_en, R.string.phq9_q7_fa, standardOptions),
+        Question(R.string.phq9_q8_en, R.string.phq9_q8_fa, standardOptions),
+        Question(R.string.phq9_q9_en, R.string.phq9_q9_fa, standardOptions, isCritical = true)
+    ),
+    results = listOf(
+        AssessmentResult(0..4, R.string.severity_minimal_en, R.string.severity_minimal_fa, R.string.steps_monitor_en, R.string.steps_monitor_fa),
+        AssessmentResult(5..9, R.string.severity_mild_en, R.string.severity_mild_fa, R.string.steps_clinical_en, R.string.steps_clinical_fa),
+        AssessmentResult(10..14, R.string.severity_moderate_en, R.string.severity_moderate_fa, R.string.steps_clinical_duration_en, R.string.steps_clinical_duration_fa),
+        AssessmentResult(15..19, R.string.severity_moderately_severe_en, R.string.severity_moderately_severe_fa, R.string.steps_active_treatment_en, R.string.steps_active_treatment_fa),
+        AssessmentResult(20..27, R.string.severity_severe_en, R.string.severity_severe_fa, R.string.steps_active_treatment_en, R.string.steps_active_treatment_fa)
+    )
+)

--- a/app/src/main/java/com/roman/zemzeme/ui/AssessmentScreen.kt
+++ b/app/src/main/java/com/roman/zemzeme/ui/AssessmentScreen.kt
@@ -1,0 +1,191 @@
+package com.roman.zemzeme.ui
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.roman.zemzeme.R
+
+@Composable
+fun AssessmentScreen(onBack: () -> Unit) {
+    var isFarsi by rememberSaveable { mutableStateOf(false) }
+    var step by rememberSaveable { mutableIntStateOf(0) }
+    var selectedAssessment by rememberSaveable { mutableStateOf<ClinicalAssessment?>(null) }
+    var showIncompleteError by rememberSaveable { mutableStateOf(false) }
+    var hasAcceptedDisclaimer by rememberSaveable { mutableStateOf(false) }
+    val mapSaver = Saver<MutableMap<Int, Int>, IntArray>(
+        save = { map -> map.flatMap { listOf(it.key, it.value) }.toIntArray() },
+        restore = { array ->
+            val map = mutableStateMapOf<Int, Int>()
+            for (i in array.indices step 2) { map[array[i]] = array[i + 1] }
+            map
+        }
+    )
+    val answers = rememberSaveable(saver = mapSaver) { mutableStateMapOf<Int, Int>() }
+    val context = LocalContext.current
+    val layoutDirection = if (isFarsi) LayoutDirection.Rtl else LayoutDirection.Ltr
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(stringResource(R.string.lang_en))
+                Switch(checked = isFarsi, onCheckedChange = { isFarsi = it }, modifier = Modifier.padding(horizontal = 8.dp))
+                Text(stringResource(R.string.lang_fa))
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+            if (step == 0) {
+                Text(text = if (isFarsi) stringResource(R.string.assessment_welcome_fa) else stringResource(R.string.assessment_welcome_en), style = MaterialTheme.typography.headlineMedium)
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(text = if (isFarsi) stringResource(R.string.assessment_intro_fa) else stringResource(R.string.assessment_intro_en), style = MaterialTheme.typography.bodyLarge)
+                Spacer(modifier = Modifier.height(24.dp))
+                
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { hasAcceptedDisclaimer = !hasAcceptedDisclaimer }
+                        .padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(checked = hasAcceptedDisclaimer, onCheckedChange = { hasAcceptedDisclaimer = it })
+                    Text(
+                        text = if (isFarsi) stringResource(R.string.disclaimer_accept_fa) else stringResource(R.string.disclaimer_accept_en),
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                
+                Button(onClick = { step = 1 }, enabled = hasAcceptedDisclaimer, modifier = Modifier.fillMaxWidth()) {
+                    Text(if (isFarsi) stringResource(R.string.assessment_start_fa) else stringResource(R.string.assessment_start_en))
+                }
+            } else if (step == 1) {
+                Text(text = if (isFarsi) stringResource(R.string.assessment_selection_title_fa) else stringResource(R.string.assessment_selection_title_en), style = MaterialTheme.typography.headlineMedium)
+                Spacer(modifier = Modifier.height(24.dp))
+                Button(onClick = { selectedAssessment = gad7; step = 2 }, modifier = Modifier.fillMaxWidth()) {
+                    Text(if (isFarsi) stringResource(R.string.assessment_gad7_btn_fa) else stringResource(R.string.assessment_gad7_btn_en))
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(onClick = { selectedAssessment = phq9; step = 2 }, modifier = Modifier.fillMaxWidth()) {
+                    Text(if (isFarsi) stringResource(R.string.assessment_phq9_btn_fa) else stringResource(R.string.assessment_phq9_btn_en))
+                }
+            } else if (step == 2) {
+                selectedAssessment?.let { assessment ->
+                    Text(text = if (isFarsi) assessment.titleFa else assessment.titleEn, style = MaterialTheme.typography.headlineMedium)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(if (isFarsi) assessment.descriptionFa else assessment.descriptionEn)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    LazyColumn(modifier = Modifier.weight(1f)) {
+                        itemsIndexed(assessment.questions) { index, question ->
+                            Card(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    Text(text = "${index + 1}. ${if (isFarsi) stringResource(question.textFaRes) else stringResource(question.textEnRes)}")
+                                    question.options.forEach { option ->
+                                        val optionText = if (isFarsi) stringResource(option.textFaRes) else stringResource(option.textEnRes)
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth().selectable(
+                                                selected = (answers[index] == option.score),
+                                                onClick = { answers[index] = option.score; showIncompleteError = false },
+                                                role = Role.RadioButton
+                                            ).semantics { contentDescription = optionText }.padding(vertical = 8.dp),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            RadioButton(selected = (answers[index] == option.score), onClick = null)
+                                            Text(text = optionText, modifier = Modifier.padding(start = 8.dp))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (showIncompleteError) {
+                        Text(text = if (isFarsi) stringResource(R.string.assessment_incomplete_error_fa) else stringResource(R.string.assessment_incomplete_error_en), color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(vertical = 8.dp))
+                    }
+                    Button(
+                        onClick = {
+                            val requiredIndices = assessment.questions.indices.toList()
+                            if (answers.keys.containsAll(requiredIndices)) {
+                                showIncompleteError = false
+                                step = 3
+                            } else {
+                                showIncompleteError = true
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) { Text(if (isFarsi) stringResource(R.string.assessment_view_results_fa) else stringResource(R.string.assessment_view_results_en)) }
+                }
+            } else if (step == 3) {
+                selectedAssessment?.let { assessment ->
+                    val totalScore = answers.values.sum()
+                    val resultTier = assessment.results.firstOrNull { totalScore in it.scoreRange }
+                    val triggeredCritical = assessment.questions.mapIndexedNotNull { index, q -> if (q.isCritical && (answers[index] ?: 0) > 0) true else null }.isNotEmpty()
+                    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
+                        Text(text = if (isFarsi) stringResource(R.string.assessment_total_score_fa, totalScore) else stringResource(R.string.assessment_total_score_en, totalScore), style = MaterialTheme.typography.displaySmall)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        if (resultTier != null) {
+                            Text(text = if (isFarsi) stringResource(R.string.assessment_severity_fa, stringResource(resultTier.severityFaRes)) else stringResource(R.string.assessment_severity_en, stringResource(resultTier.severityEnRes)), style = MaterialTheme.typography.headlineSmall)
+                            Text(if (isFarsi) stringResource(R.string.assessment_next_steps_fa, stringResource(resultTier.nextStepsFaRes)) else stringResource(R.string.assessment_next_steps_en, stringResource(resultTier.nextStepsEnRes)))
+                        }
+                        if (triggeredCritical) {
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.error)) {
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    Text(text = if (isFarsi) stringResource(R.string.assessment_critical_warning_fa) else stringResource(R.string.assessment_critical_warning_en), color = MaterialTheme.colorScheme.onError, fontWeight = FontWeight.Bold)
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                                        Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            if (isFarsi) {
+                                                Button(onClick = { context.startActivity(Intent(Intent.ACTION_DIAL, Uri.parse("tel:1480"))) }, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onErrorContainer), modifier = Modifier.fillMaxWidth()) { Text(stringResource(R.string.assessment_call_1480), color = MaterialTheme.colorScheme.onError) }
+                                                Button(onClick = { context.startActivity(Intent(Intent.ACTION_DIAL, Uri.parse("tel:123"))) }, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onErrorContainer), modifier = Modifier.fillMaxWidth()) { Text(stringResource(R.string.assessment_call_123), color = MaterialTheme.colorScheme.onError) }
+                                                Button(onClick = { context.startActivity(Intent(Intent.ACTION_DIAL, Uri.parse("tel:115"))) }, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onErrorContainer), modifier = Modifier.fillMaxWidth()) { Text(stringResource(R.string.assessment_call_115), color = MaterialTheme.colorScheme.onError) }
+                                            } else {
+                                                Button(onClick = { context.startActivity(Intent(Intent.ACTION_DIAL, Uri.parse("tel:988"))) }, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onErrorContainer), modifier = Modifier.fillMaxWidth()) { Text(stringResource(R.string.assessment_call_988), color = MaterialTheme.colorScheme.onError) }
+                                                Button(onClick = { context.startActivity(Intent(Intent.ACTION_DIAL, Uri.parse("tel:911"))) }, colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.onErrorContainer), modifier = Modifier.fillMaxWidth()) { Text(stringResource(R.string.assessment_call_911), color = MaterialTheme.colorScheme.onError) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Button(onClick = { 
+                        answers.clear()
+                        step = 0
+                        hasAcceptedDisclaimer = false
+                        selectedAssessment = null
+                        onBack() 
+                    }, modifier = Modifier.fillMaxWidth()) {
+                        Text(if (isFarsi) stringResource(R.string.assessment_finish_back_fa) else stringResource(R.string.assessment_finish_back_en))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/roman/zemzeme/ui/HomeScreen.kt
+++ b/app/src/main/java/com/roman/zemzeme/ui/HomeScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.HealthAndSafety
+import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.DeleteForever
 import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material.icons.outlined.Edit
@@ -160,6 +162,9 @@ fun HomeScreen(
 
     // Refresh account confirmation dialog
     var showRefreshDialog by remember { mutableStateOf(false) }
+
+    // Clinical assessment state
+    var isAssessmentOpen by remember { mutableStateOf(false) }
 
     // Mesh intro dialog (first-time only)
     val meshIntroPrefs = remember { context.getSharedPreferences("mesh_intro", android.content.Context.MODE_PRIVATE) }
@@ -355,6 +360,17 @@ fun HomeScreen(
             Modifier.fillMaxSize().padding(padding),
             contentPadding = PaddingValues(vertical = 8.dp)
         ) {
+            // Pinned Assessment Bot Row
+            item(key = "assessment_bot") {
+                PinnedAssessmentBotRow(
+                    onClick = { isAssessmentOpen = true }
+                )
+                HorizontalDivider(
+                    color = colorScheme.outline.copy(alpha = 0.3f),
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+
             // ── NEARBY ──
             item(key = "nearby_header") { SectionHeader(stringResource(R.string.section_nearby)) }
 
@@ -682,6 +698,19 @@ fun HomeScreen(
             onDismiss = { showDebugSheet = false },
             meshService = chatViewModel.meshService
         )
+    }
+
+
+    // Render Assessment Screen in Dialog
+    if (isAssessmentOpen) {
+        Dialog(
+            onDismissRequest = { isAssessmentOpen = false },
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            Surface(modifier = Modifier.fillMaxSize()) {
+                AssessmentScreen(onBack = { isAssessmentOpen = false })
+            }
+        }
     }
 }
 
@@ -1124,4 +1153,23 @@ private fun RenameGroupDialog(currentName: String, onDismiss: () -> Unit, onConf
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel)) } }
     )
+}
+
+// Assessment Bot Row
+@Composable
+fun PinnedAssessmentBotRow(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable { onClick() }.background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)).padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.size(50.dp).background(MaterialTheme.colorScheme.primaryContainer, CircleShape), contentAlignment = Alignment.Center) {
+            Icon(imageVector = Icons.Default.HealthAndSafety, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimaryContainer)
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = "${stringResource(R.string.assessment_tab_title_fa)} | ${stringResource(R.string.assessment_tab_title_en)}", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+            Text(text = "${stringResource(R.string.assessment_tab_subtitle_en)} | ${stringResource(R.string.assessment_tab_subtitle_fa)}", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+        Icon(imageVector = Icons.Default.PushPin, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(20.dp))
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -690,12 +690,184 @@
     <string name="fab_choose_city">Choose city</string>
     <string name="fab_join_group">Join group</string>
     <string name="fab_create_group">Create group</string>
+    <string name="fab_clinical_assessment">Clinical Assessment</string>
+
+    <!-- Assessment Screen -->
+    <string name="assessment_english">English</string>
+    <string name="assessment_farsi">فارسی</string>
+    <string name="assessment_view_results">View Results</string>
+    <string name="assessment_farsi_view_results">مشاهده نتایج</string>
+    <string name="assessment_back">Finish / Back</string>
+    <string name="assessment_farsi_back">بازگشت</string>
+    <string name="assessment_total_score">Total Score: %1$d</string>
+    <string name="assessment_severity">Severity: %1$s</string>
+    <string name="assessment_next_steps">Next Steps: %1$s</string>
+    <string name="assessment_suicide_risk_warning">CRITICAL: Patient responded positively to self-harm thoughts. Immediate risk assessment required.</string>
+    <string name="assessment_suicide_risk_warning_farsi">هشدار: بیمار افکار خودکشی دارد. ارزیابی فوری خطر الزامی است.</string>
+    <string name="assessment_crisis_resources">Please seek immediate help: Call 988 (US Suicide Prevention) or go to your nearest emergency room.</string>
+    <string name="assessment_crisis_resources_farsi">لطفاً فوراً کمک بخواهید: با شماره 988 (پیشگیری از خودکشی) تماس بگیرید یا به نزدیک‌ترین اورژانس مراجعه کنید.</string>
+
+    <!-- Assessment Options Strings -->
+    <string name="opt_not_at_all_en">Not at all</string>
+    <string name="opt_not_at_all_fa">اصلاً</string>
+    <string name="opt_several_days_en">Several days</string>
+    <string name="opt_several_days_fa">چند روز</string>
+    <string name="opt_more_than_half_en">More than half the days</string>
+    <string name="opt_more_than_half_fa">بیش از نیمی از روزها</string>
+    <string name="opt_nearly_every_en">Nearly every day</string>
+    <string name="opt_nearly_every_fa">تقریباً هر روز</string>
+
+    <!-- GAD-7 Questions -->
+    <string name="gad7_q1_en">Feeling nervous, anxious, or on edge</string>
+    <string name="gad7_q1_fa">احساس عصبی بودن، اضطراب یا تنش</string>
+    <string name="gad7_q2_en">Not being able to stop or control worrying</string>
+    <string name="gad7_q2_fa">ناتوانی در توقف یا کنترل نگرانی</string>
+    <string name="gad7_q3_en">Worrying too much about different things</string>
+    <string name="gad7_q3_fa">نگرانی بیش از حد در مورد مسائل مختلف</string>
+    <string name="gad7_q4_en">Trouble relaxing</string>
+    <string name="gad7_q4_fa">مشکل در آرام شدن (ریلکس کردن)</string>
+    <string name="gad7_q5_en">Being so restless that it is hard to sit still</string>
+    <string name="gad7_q5_fa">بی‌قراری به حدی که نشستن در یک جا دشوار باشد</string>
+    <string name="gad7_q6_en">Becoming easily annoyed or irritable</string>
+    <string name="gad7_q6_fa">به سادگی آزرده یا تحریک‌پذیر شدن</string>
+    <string name="gad7_q7_en">Feeling afraid as if something awful might happen</string>
+    <string name="gad7_q7_fa">احساس ترس از اینکه ممکن است اتفاق وحشتناکی بیفتد</string>
+
+    <!-- PHQ-9 Questions -->
+    <string name="phq9_q1_en">Little interest or pleasure in doing things</string>
+    <string name="phq9_q1_fa">کمبود علاقه یا لذت در انجام کارها</string>
+    <string name="phq9_q2_en">Feeling down, depressed, or hopeless</string>
+    <string name="phq9_q2_fa">احساس ناراحتی، افسردگی یا ناامیدی</string>
+    <string name="phq9_q3_en">Trouble falling or staying asleep, or sleeping too much</string>
+    <string name="phq9_q3_fa">مشکل در به خواب رفتن، بیدار ماندن یا خوابیدن بیش از حد</string>
+    <string name="phq9_q4_en">Feeling tired or having little energy</string>
+    <string name="phq9_q4_fa">احساس خستگی یا کمبود انرژی</string>
+    <string name="phq9_q5_en">Poor appetite or overeating</string>
+    <string name="phq9_q5_fa">کم‌اشتهایی یا پرخوری</string>
+    <string name="phq9_q6_en">Feeling bad about yourself, or that you are a failure or have let yourself or your family down</string>
+    <string name="phq9_q6_fa">احساس بد نسبت به خود، یا اینکه یک شکست‌خورده هستید یا خانواده‌تان را ناامید کرده‌اید</string>
+    <string name="phq9_q7_en">Trouble concentrating on things, such as reading the newspaper or watching television</string>
+    <string name="phq9_q7_fa">مشکل در تمرکز روی کارها، مانند روزنامه خواندن یا تماشای تلویزیون</string>
+    <string name="phq9_q8_en">Moving or speaking so slowly that other people could have noticed? Or so fidgety or restless that you have been moving a lot more than usual</string>
+    <string name="phq9_q8_fa">حرکت یا صحبت کردن به قدری کند که دیگران متوجه شوند؟ یا به قدری بی‌قرار که خیلی بیشتر از حد معمول حرکت می‌کنید</string>
+    <string name="phq9_q9_en">Thoughts that you would be better off dead, or of hurting yourself</string>
+    <string name="phq9_q9_fa">افکاری درباره اینکه اگر مرده بودید بهتر بود، یا آسیب به خودتان</string>
+
+    <!-- Medical Disclaimer -->
+    <string name="medical_disclaimer_title">MEDICAL DISCLAIMER</string>
+    <string name="medical_disclaimer_title_fa">سلب مسئولیت پزشکی</string>
+    <string name="medical_disclaimer_en">This tool is strictly for screening purposes. It is NOT a clinical diagnosis and cannot replace a medical professional. If you are in crisis, seek immediate emergency help.</string>
+    <string name="medical_disclaimer_fa">این ابزار صرفاً جنبه و غربالگری دارد و به هیچ وجه جایگزین تشخیص قطعی پزشک متخصص نیست. در صورت بروز شرایط بحرانی، لطفاً فوراً با اورژانس تماس بگیرید.</string>
+    <string name="medical_disclaimer_accept_en">I Understand and Agree</string>
+    <string name="medical_disclaimer_accept_fa">شرایط را مطالعه کردم و می‌پذیرم</string>
+
+    <!-- Crisis Intervention -->
+    <string name="crisis_warning_en">CRITICAL: Self-harm risk detected. Please contact a crisis hotline immediately.</string>
+    <string name="crisis_warning_fa">هشدار مهم: خطر اورژانسی. لطفاً بی‌درنگ با خطوط ویژه بحران روان‌شناختی تماس بگیرید.</string>
+    <string name="crisis_call_1480_en">Call 1480 (IR)</string>
+    <string name="crisis_call_1480_fa">تماس با 1480 (ایران)</string>
+    <string name="crisis_call_988">Call 988 (US)</string>
+
+    <!-- Results Screen Labels -->
+    <string name="total_score_en">Total Score: %1$d</string>
+    <string name="total_score_fa">مجموع امتیاز شما: %1$d</string>
+    <string name="severity_en">Severity: %1$s</string>
+    <string name="severity_fa">وضعیت ارزیابی: %1$s</string>
+    <string name="next_steps_en">Next Steps: %1$s</string>
+    <string name="next_steps_fa">اقدام پیشنهادی: %1$s</string>
+
+    <!-- Button Labels -->
+    <string name="view_results_en">View Results</string>
+    <string name="view_results_fa">مشاهده نتیجه ارزیابی</string>
+    <string name="finish_back_en">Finish / Back</string>
+    <string name="finish_back_fa">پایان ارزیابی و بازگشت</string>
+
+    <!-- Severity Levels -->
+    <string name="severity_minimal_en">Minimal or none</string>
+    <string name="severity_minimal_fa">حداقل یا هیچ</string>
+    <string name="severity_mild_en">Mild</string>
+    <string name="severity_mild_fa">خفیف</string>
+    <string name="severity_moderate_en">Moderate</string>
+    <string name="severity_moderate_fa">متوسط</string>
+    <string name="severity_moderately_severe_en">Moderately severe</string>
+    <string name="severity_moderately_severe_fa">نسبتاً شدید</string>
+    <string name="severity_severe_en">Severe</string>
+    <string name="severity_severe_fa">شدید</string>
+    <string name="severity_no_anxiety_en">No anxiety disorder</string>
+    <string name="severity_no_anxiety_fa">اضطراب وجود ندارد</string>
+
+    <!-- Next Steps Recommendations -->
+    <string name="steps_monitor_en">Monitor. May not require treatment.</string>
+    <string name="steps_monitor_fa">پایش؛ ممکن است نیاز به درمان نداشته باشد.</string>
+    <string name="steps_monitor_symptom_en">Monitor symptom severity.</string>
+    <string name="steps_monitor_symptom_fa">پایش شدت علائم.</string>
+    <string name="steps_clinical_en">Use clinical judgment to determine necessity of treatment.</string>
+    <string name="steps_clinical_fa">استفاده از قضاوت بالینی برای تعیین ضرورت درمان.</string>
+    <string name="steps_clinical_duration_en">Use clinical judgment (symptom duration, functional impairment).</string>
+    <string name="steps_clinical_duration_fa">استفاده از قضاوت بالینی بر اساس مدت علائم.</string>
+    <string name="steps_active_treatment_en">Warrants active treatment with psychotherapy, medications, or combination.</string>
+    <string name="steps_active_treatment_fa">نیاز به درمان فعال با روان‌درمانی، دارو یا ترکیبی از هر دو.</string>
+    <string name="steps_referral_en">Active treatment probably warranted. Referral to mental health professional.</string>
+    <string name="steps_referral_fa">احتمالاً نیاز به درمان فعال. ارجاع به متخصص بهداشت روان.</string>
+
+    <!-- Validation Error -->
+    <string name="validation_incomplete_en">Please answer all questions before proceeding.</string>
+    <string name="validation_incomplete_fa">لطفاً پیش از ادامه به تمامی سوالات پاسخ دهید.</string>
 
     <!-- Section headers -->
     <string name="section_nearby">Nearby</string>
     <string name="section_geographic_groups">Geographic Groups</string>
     <string name="section_my_groups">My Groups</string>
     <string name="section_contacts">Contacts</string>
+
+    <!-- Pinned Assessment Bot Row -->
+    <string name="assessment_bot_title_en">Depression &amp; Anxiety</string>
+    <string name="assessment_bot_title_fa">ارزیابی افسردگی و اضطراب</string>
+    <string name="assessment_bot_subtitle_en">Tap to start</string>
+    <string name="assessment_bot_subtitle_fa">برای شروع ضربه بزنید</string>
+
+    <!-- Assessment Tab -->
+    <string name="assessment_tab_title_en">Anxiety / Depression Screening</string>
+    <string name="assessment_tab_title_fa">غربالگری اضطراب / افسردگی</string>
+    <string name="assessment_tab_subtitle_en">Tap to start</string>
+    <string name="assessment_tab_subtitle_fa">برای شروع ضربه بزنید</string>
+    <string name="lang_en">EN</string>
+    <string name="lang_fa">FA</string>
+
+    <!-- New consolidated assessment strings -->
+    <string name="assessment_welcome_en">Welcome to the Mental Health Assessment Tool</string>
+    <string name="assessment_welcome_fa">به ابزار ارزیابی سلامت روان خوش آمدید</string>
+    <string name="assessment_intro_en">This tool helps you check your current depression or anxiety status.\n\nPlease note that these questionnaires are designed strictly for screening purposes and cannot replace a professional clinical diagnosis. Results are provided as a guide only.</string>
+    <string name="assessment_intro_fa">این ابزار به شما کمک می‌کند وضعیت فعلی افسردگی یا اضطراب خود را بررسی کنید.\n\nلطفاً توجه داشته باشید که این پرسشنامه‌ها صرفاً برای غربالگری طراحی شده‌اند و به هیچ وجه جایگزین تشخیص متخصص بالینی نیستند. نتایج تنها به عنوان یک راهنما ارائه می‌شوند.</string>
+    <string name="disclaimer_accept_en">I understand and agree</string>
+    <string name="disclaimer_accept_fa">شرایط را مطالعه کردم و می‌پذیرم</string>
+    <string name="assessment_start_en">Start Assessment</string>
+    <string name="assessment_start_fa">شروع ارزیابی</string>
+    <string name="assessment_selection_title_en">What would you like to assess?</string>
+    <string name="assessment_selection_title_fa">مایلید کدام مورد را بررسی کنید؟</string>
+    <string name="assessment_gad7_btn_en">Anxiety Assessment (GAD-7)</string>
+    <string name="assessment_gad7_btn_fa">ارزیابی اضطراب (GAD-7)</string>
+    <string name="assessment_phq9_btn_en">Depression Assessment (PHQ-9)</string>
+    <string name="assessment_phq9_btn_fa">ارزیابی افسردگی (PHQ-9)</string>
+    <string name="assessment_incomplete_error_en">Please answer all questions before proceeding.</string>
+    <string name="assessment_incomplete_error_fa">لطفاً پیش از ادامه به تمامی سوالات پاسخ دهید.</string>
+    <string name="assessment_view_results_en">View Results</string>
+    <string name="assessment_view_results_fa">مشاهده نتیجه ارزیابی</string>
+    <string name="assessment_total_score_en">Total Score: %1$d</string>
+    <string name="assessment_total_score_fa">مجموع امتیاز شما: %1$d</string>
+    <string name="assessment_severity_en">Severity: %1$s</string>
+    <string name="assessment_severity_fa">وضعیت ارزیابی: %1$s</string>
+    <string name="assessment_next_steps_en">Next Steps: %1$s</string>
+    <string name="assessment_next_steps_fa">اقدام پیشنهادی: %1$s</string>
+    <string name="assessment_critical_warning_en">CRITICAL: Self-harm risk detected. Please contact a crisis hotline immediately.</string>
+    <string name="assessment_critical_warning_fa">هشدار مهم: خطر اورژانسی. لطفاً بی‌درنگ با خطوط ویژه بحران تماس بگیرید.</string>
+    <string name="assessment_finish_back_en">Finish / Back</string>
+    <string name="assessment_finish_back_fa">پایان ارزیابی و بازگشت</string>
+    <string name="assessment_call_1480">تماس با 1480 (صدای مشاور)</string>
+    <string name="assessment_call_123">تماس با 123 (اورژانس اجتماعی)</string>
+    <string name="assessment_call_115">تماس با 115 (اورژانس پزشکی)</string>
+    <string name="assessment_call_988">Call 988 (Crisis Lifeline)</string>
+    <string name="assessment_call_911">Call 911 (Emergency)</string>
 
     <!-- Group ID label -->
     <string name="label_group_id_fmt">Group ID: %1$s</string>


### PR DESCRIPTION
## Motivation & Context
In high-stress environments where users rely on secure tools like Zemzeme, mental health crises are a common but under-addressed reality. This PR introduces a fully offline, on-device Mental Health Assessment tool. It allows users to self-screen for anxiety and depression using globally validated clinical questionnaires, providing immediate, localized guidance without ever transmitting their sensitive health data over the network.

## Key Features
* **Validated Clinical Tools:** Implements the standard GAD-7 (Anxiety) and PHQ-9 (Depression) screening questionnaires.
* **Native Bilingual Support:** Full localization for both English and Farsi, including dynamic RTL layout switching to ensure natural readability for Persian speakers.
* **Isolated Scope:** These additions are strictly confined to the UI and local state management, ensuring zero interference with the app's core mesh or P2P networking logic.

## Clinical Safety & Liability Guardrails
* **Explicit Medical Consent:** Users are hard-blocked from starting the assessment until they explicitly check an "I agree" box acknowledging that the tool is strictly for screening and is *not* a medical diagnosis.
* **Active Crisis Intervention:** If the user indicates self-harm risk (e.g., scoring >0 on the critical PHQ-9 question), the app bypasses standard results and triggers a high-visibility critical warning.
* **Localized Emergency Routing:** The crisis screen instantly renders clickable buttons to dial local emergency services using `ACTION_DIAL`. 
  * *Farsi locale:* Routes to 1480 (صدای مشاور), 123 (اورژانس اجتماعی), and 115 (اورژانس پزشکی).
  * *English locale:* Routes to 988 (Crisis Lifeline) and 911.

## Privacy & Data Handling
* **Zero Data Retention:** Aligned with Zemzeme's privacy-first architecture, this feature collects zero data. Answers are held entirely in ephemeral `rememberSaveable` Compose states and are instantly destroyed the moment the user finishes the assessment, exits the screen, or closes the app.